### PR TITLE
Add ACCESS_COARSE_LOCATION to AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="comegg_electric_unicycle.github.eggunicycle">
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.VIBRATE"/>


### PR DESCRIPTION
Fixes: #1 

I think this is the change that is needed, but I'm not able to test it because I don't have the tools to build apk's on my system. The workaround I attempted in https://github.com/EGG-electric-unicycle/egg_app/issues/1#issuecomment-263677067 was by directly modifying the APK and repacking it using instructions found here: http://www.howtutor.com/viewtopic.php?t=1411